### PR TITLE
add icon for the "Open as a Jupyter Notebook" button in the Editor Actions area

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
         "commands": [
             {
                 "command": "jupyter.openAsPairedNotebook",
-                "title": "Open as a Jupyter Notebook"
+                "title": "Open as a Jupyter Notebook",
+                "category": "jupytext",
+                "icon": "$(notebook-edit)"
             }
         ],
         "menus": {


### PR DESCRIPTION
this is a fix for the issue notebookPowerTools/vscode-jupytext#18 

I could not file the PR with this upstream repo as it is lingering behind

I have a few other minor/cosmetic improvements to propose as well, but let us start with this one :)