### PR TITLE
the list of applicable languages is customizable as the jupytext.languages setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,17 @@
                 "title": "Open as a Jupyter Notebook"
             }
         ],
+        "configuration": {
+            "title": "Jupytext",
+            "properties": {
+                "jupytext.languages": {
+                    "type": "string",
+                    "editPresentation": "multilineText",
+                    "default": "R\nbash\nc++\nclojure\ncoconut\ncsharp\nfsharp\ngroovy\nidl\njava\njavascript\njulia\nmatlab\npowershell\npython\nq\nrobotframework\nrust\nsage\nscala\nscheme\nsos\ntypescript",
+                    "markdownDescription": "The **language names** *(one per line)* that can be opened with this extension\n\nFor example if you have `.ts` files and you do not want them to have the *Open as a Jupyter Notebook* thingy to be available on these files, remove `typescript` from this list "
+                }
+            }
+        },
         "menus": {
             "explorer/context": [
                 {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,24 +1,23 @@
-import { commands, Uri, window } from 'vscode';
+import { commands, Uri, window, workspace } from 'vscode';
 import { JupyterNotebookView, jupytextScheme } from './constants';
 import { convertToNotebook } from './conversion';
 
+// see the default values of jupytext.languages in package.json
+// this should reflect the set of available languages
+// as defined in python-libs/jupytext/languages.py
+// >>> from jupytext.languages import _SCRIPT_EXTENSIONS
+// >>> langs = sorted(list({ record['language'] for ext, record in _SCRIPT_EXTENSIONS.items()}))
+// >>> "\n".join(langs)
 export function initialize() {
+    const config = workspace.getConfiguration('jupytext');
+    // reassemble and remove empty lines if any
+    console.log(config);
+    const langIds = config.languages.split("\n").filter((x:any) => x);
     commands.executeCommand(
         'setContext',
         'vscode-jupytext.resourceLangIds',
-        [
-            'csharp',
-            'fsharp',
-            'java',
-            'javascript',
-            'julia',
-            'markdown',
-            'powershell',
-            'python',
-            'r',
-            'rust',
-            'typescript'
-        ]);
+        langIds,
+    );
 
     commands.registerCommand('jupyter.openAsPairedNotebook', async (uri?: Uri) => {
         uri = uri || window.activeTextEditor?.document.uri ;

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,34 +1,37 @@
 import { Uri } from "vscode"
 
-export const supportedFileExtensions = {
-    ".py": {"language": "python", "comment": "#"},
-    ".coco": {"language": "coconut", "comment": "#"},
-    ".R": {"language": "R", "comment": "#"},
-    ".r": {"language": "R", "comment": "#"},
-    ".jl": {"language": "julia", "comment": "#"},
-    ".cpp": {"language": "c++", "comment": "//"},
-    ".ss": {"language": "scheme", "comment": ";;"},
-    ".clj": {"language": "clojure", "comment": ";;"},
-    ".scm": {"language": "scheme", "comment": ";;"},
-    ".sh": {"language": "bash", "comment": "#"},
-    ".ps1": {"language": "powershell", "comment": "#"},
-    ".q": {"language": "q", "comment": "/"},
-    ".m": {"language": "matlab", "comment": "%"},
-    ".pro": {"language": "idl", "comment": ";"},
-    ".js": {"language": "javascript", "comment": "//"},
-    ".ts": {"language": "typescript", "comment": "//"},
-    ".scala": {"language": "scala", "comment": "//"},
-    ".rs": {"language": "rust", "comment": "//"},
-    ".robot": {"language": "robotframework", "comment": "#"},
-    ".resource": {"language": "robotframework", "comment": "#"},
-    ".cs": {"language": "csharp", "comment": "//"},
-    ".fsx": {"language": "fsharp", "comment": "//"},
-    ".fs": {"language": "fsharp", "comment": "//"},
-    ".sos": {"language": "sos", "comment": "#"},
-    ".java": {"language": "java", "comment": "//"},
-    ".groovy": {"language": "groovy", "comment": "//"},
-    ".sage": {"language": "sage", "comment": "#"},
-}
+// NOTE
+// this is actually not used
+//
+// export const supportedFileExtensions = {
+//     ".py": {"language": "python", "comment": "#"},
+//     ".coco": {"language": "coconut", "comment": "#"},
+//     ".R": {"language": "R", "comment": "#"},
+//     ".r": {"language": "R", "comment": "#"},
+//     ".jl": {"language": "julia", "comment": "#"},
+//     ".cpp": {"language": "c++", "comment": "//"},
+//     ".ss": {"language": "scheme", "comment": ";;"},
+//     ".clj": {"language": "clojure", "comment": ";;"},
+//     ".scm": {"language": "scheme", "comment": ";;"},
+//     ".sh": {"language": "bash", "comment": "#"},
+//     ".ps1": {"language": "powershell", "comment": "#"},
+//     ".q": {"language": "q", "comment": "/"},
+//     ".m": {"language": "matlab", "comment": "%"},
+//     ".pro": {"language": "idl", "comment": ";"},
+//     ".js": {"language": "javascript", "comment": "//"},
+//     ".ts": {"language": "typescript", "comment": "//"},
+//     ".scala": {"language": "scala", "comment": "//"},
+//     ".rs": {"language": "rust", "comment": "//"},
+//     ".robot": {"language": "robotframework", "comment": "#"},
+//     ".resource": {"language": "robotframework", "comment": "#"},
+//     ".cs": {"language": "csharp", "comment": "//"},
+//     ".fsx": {"language": "fsharp", "comment": "//"},
+//     ".fs": {"language": "fsharp", "comment": "//"},
+//     ".sos": {"language": "sos", "comment": "#"},
+//     ".java": {"language": "java", "comment": "//"},
+//     ".groovy": {"language": "groovy", "comment": "//"},
+//     ".sage": {"language": "sage", "comment": "#"},
+// }
 
 export function isConversionSupportedWithoutPython(uri: Uri){
     if (uri.fsPath.toLowerCase().endsWith('.py')){


### PR DESCRIPTION

a fix for https://github.com/notebookPowerTools/vscode-jupytext/issues/20

here's what the settings looks like

<img width="833" alt="image" src="https://user-images.githubusercontent.com/4519227/233843790-1777e86e-7258-4cd9-be62-b32c1b82f04f.png">
